### PR TITLE
added metadata file

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,0 +1,7 @@
+name             'filehelper'
+maintainer       'Jens Segers'
+maintainer_email ''
+license          ''
+description      'Some handy Chef definitions for when you want to replace text and lines in files.'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version          '1.0'


### PR DESCRIPTION
Simple, but powerful tool.

A lot of chef related tools (berkshelf, etc.) require a metadata.rb file to utilize a cookbook.

I didn't add an email or license definition.
